### PR TITLE
Fix mkfs make_sdcard.sh

### DIFF
--- a/scripts/make_sdcard.sh
+++ b/scripts/make_sdcard.sh
@@ -111,7 +111,7 @@ parted "$DEVICE" mkpart primary 0% 100% --script
 echo "Formatting partition to FAT32..."
 
 # Format FAT32 partition
-mkfs.fat -F32 /dev/sda1
+mkfs.fat -F32 "$DEVICE"1
 
 echo "Mounting new partition..."
 


### PR DESCRIPTION
The device name used with mkfs was hard-coded “sda”, so I replaced it with the variable “$Device”.